### PR TITLE
Include Compute Engine API in GCP Project Services

### DIFF
--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -17,6 +17,7 @@ default_regions = {
 
 gcp_project_services = [
   "cloudbuild.googleapis.com",
+  "compute.googleapis.com",
   "container.googleapis.com",
   "artifactregistry.googleapis.com"
 ]


### PR DESCRIPTION
Enable Compute Engine API for VPC resources