### PR TITLE
Remove shell sign from codeblocks to resolve #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ To run the Game Demo install, you will need the following applications installed
 Once you have Google Cloud CLI installed, you will need to authenticate against Google Cloud:
 
 ```shell
-$ gcloud auth application-default login
+gcloud auth application-default login
 ```
 
 and then set your Google Cloud Project project name/PROJECT_ID:
 
 ```shell
-$ gcloud config set project <PROJECT_ID>
+gcloud config set project <PROJECT_ID>
 ```
 
 Clone this directory locally and, we'll also set an environment variable to it's root directory, for easy navigation:
 
 ```shell
-$ git clone https://github.com/googleforgames/global-multiplayer-demo.git
-$ cd global-multiplayer-demo
-$ export GAME_DEMO_HOME=$(pwd)
+git clone https://github.com/googleforgames/global-multiplayer-demo.git
+cd global-multiplayer-demo
+export GAME_DEMO_HOME=$(pwd)
 ```
 
 ### Provision
@@ -39,9 +39,9 @@ $ export GAME_DEMO_HOME=$(pwd)
 Initialize Terraform  & configure variables
 
 ```shell
-$ cd $GAME_DEMO_HOME/infrastructure
-$ terraform init
-$ cp terraform.tfvars.sample terraform.tfvars
+cd $GAME_DEMO_HOME/infrastructure
+terraform init
+cp terraform.tfvars.sample terraform.tfvars
 
 # Edit terraform.tfvars, especially <PROJECT_ID>
 ```
@@ -49,7 +49,7 @@ $ cp terraform.tfvars.sample terraform.tfvars
 Provision the infrastructure.
 
 ```shell
-$ terraform apply
+terraform apply
 ```
 
 ### Deploy Agones To GKE Clusters
@@ -61,8 +61,8 @@ The Agones deployment is in two steps: The Initial Install and the Allocation En
 Replace the` _RELEASE_NAME` substitution with a unique build name. Cloudbuild will deploy Agones using Cloud Deploy.
 
 ```shell
-$ cd $GAME_DEMO_HOME/infrastructure/deploy/agones/install
-$ gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
+cd $GAME_DEMO_HOME/infrastructure/deploy/agones/install
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
 ```
 
 You can monitor the status of the deployment through the Cloud Logging URL returned by the `gcloud builds` command as well as the Kubernetes Engine/Worloads panel in the GCP Console. Once the Worloads have been marked as OK, you can proceed to apply the Allocation Endpoint Patch.
@@ -71,8 +71,8 @@ You can monitor the status of the deployment through the Cloud Logging URL retur
 After the Agones install has completed and the GKE Workloads show complete, run the Allocation Endpoint Patch Cloud Deploy to apply the appropriate endpoint patches to each cluster:
 
 ```shell
-$ cd $GAME_DEMO_HOME/infrastructure/deploy/agones/endpoint-patch/
-$ gcloud builds submit --config=cloudbuild.yaml
+cd $GAME_DEMO_HOME/infrastructure/deploy/agones/endpoint-patch/
+gcloud builds submit --config=cloudbuild.yaml
 ```
 
 ***NOTE*** - The cloudbuild.yaml, kustomization.yaml & skaffold.yaml files will not exist until Terraform runs for the first time! The templates used for these files are stored in `files/agones/`.
@@ -96,8 +96,8 @@ gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-
 Replace the` _RELEASE_NAME` substitution with a unique build name. Cloudbuild will deploy Spanner applications using Cloud Deploy.
 
 ```shell
-$ cd $GAME_DEMO_HOME/infrastructure/deploy/spanner/install
-$ gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
+cd $GAME_DEMO_HOME/infrastructure/deploy/spanner/install
+gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
 ```
 
 ## Game Client


### PR DESCRIPTION
Closes #60.  This is a bit of a nitpick, but README copy/pasta isn't working correctly today because `$` is included in the codeblocks and is getting included as terminal input.