### PR TITLE
Add Cloud Shell button. Closes Issue #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ To run the Game Demo install, you will need the following applications installed
 * [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 * [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
 
+You can also click on the following icon to open this repository in a 'batteries-included' [Google Cloud Shell](https://cloud.google.com/shell) web development environment.
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fgoogleforgames%2Fglobal-multiplayer-demo.git&cloudshell_git_branch=main&cloudshell_open_in_editor=README.md&cloudshell_workspace=.)
+
 ## Google Cloud Auth
 
 Once you have Google Cloud CLI installed, you will need to authenticate against Google Cloud:


### PR DESCRIPTION
This closes #57 

@markmandel  *Important caveats* on this PR:

- Since this repo is currently private and (Github basic auth is no longer a thing), the current "open in cloud shell" redirect will actually fail to clone the repo because it leverages the repo's HTTPS URL and won't be able to access the repo in an authenticated manner.   
- This is easily fixed by adding the `git@github...git` repo path in the Cloud Shell button, _**however**_, once you make this repo public you will not want to force SSH repo access because the vast majority of Github users will not have their Github SSH keys configured with their Cloud Shell accounts.  (So most people's clone-a-repo Cloud Shell experience will fail for that reason.) 
- My suggestion, and the approach I adopted in this PR, is to include the HTTPS repo URL and configure things for your ultimate end state (i.e., public repo).   As part of this PR review, you could quickly make this repo "public", do a quick test of the Cloud Shell button experience, and then make the repo "private" again once you've confidentially verified functionality.
