### PR TITLE
Randomize endpoint service name to avoid conflicts when recreating infra resources

### DIFF
--- a/infrastructure/allocation-endpoint.tf
+++ b/infrastructure/allocation-endpoint.tf
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+# Generate random string to endpoint service name to avoid the following error when deleting/recreating endpoint service
+#   Error: googleapi: Error 400: Service global-game-us-central1-02.endpoints.global-game-sandbox.cloud.goog 
+#   has been deleted and will be purged after 30 days. To reuse this service, please undelete the service
+#   following https://cloud.google.com/service-infrastructure/docs/create-services#undeleting., failedPrecondition ...
+resource "random_string" "endpoint_random_string" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
 resource "google_endpoints_service" "endpoints_service" {
   for_each     = var.game_gke_clusters
-  service_name = "${each.key}.endpoints.${var.project}.cloud.goog"
+  service_name = "${each.key}-${random_string.endpoint_random_string.result}.endpoints.${var.project}.cloud.goog"
   grpc_config = templatefile(
     "${path.module}/files/agones/api_config.yaml.tpl", {
-      service-name    = "${each.key}.endpoints.${var.project}.cloud.goog"
+      service-name    = "${each.key}-${random_string.endpoint_random_string.result}.endpoints.${var.project}.cloud.goog"
       service-account = google_service_account.ae_sa.email
     }
   )
@@ -95,7 +105,7 @@ resource "google_cloud_run_service" "aep_cloud_run" {
         }
         env {
           name  = "AUDIENCE"
-          value = "${each.key}.endpoints.${var.project}.cloud.goog"
+          value = "${each.key}-${random_string.endpoint_random_string.result}.endpoints.${var.project}.cloud.goog"
         }
         env {
           name = "SA_KEY"
@@ -228,6 +238,7 @@ resource "local_file" "patch-agones-manifest" {
       project_id   = var.project
       location     = each.value.region
       cluster_name = each.key
+      service_name = "${each.key}-${random_string.endpoint_random_string.result}.endpoints.${var.project}.cloud.goog"
       sa_email     = google_service_account.ae_sa.email
   })
   filename = "${path.module}/deploy/agones/endpoint-patch/patch-agones-allocator-${each.key}.yaml"

--- a/infrastructure/files/agones/patch-agones-allocator.yaml.tpl
+++ b/infrastructure/files/agones/patch-agones-allocator.yaml.tpl
@@ -94,7 +94,7 @@ spec:
         - --listener_port=9443
         - --generate_self_signed_cert
         - --backend=grpc://127.0.0.1:8443
-        - --service=${cluster_name}.endpoints.${project_id}.cloud.goog
+        - --service=${service_name}
         - --rollout_strategy=managed
         image: gcr.io/endpoints-release/endpoints-runtime:2
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Adds a random string to the endpoint name to avoid the following error when deleting terraform resources then recreating:

```
│ Error: googleapi: Error 400: Service global-game-us-central1-02.endpoints.global-game-sandbox.cloud.goog has been deleted and will be purged after 30 days. To reuse this service, please undelete the service following https://cloud.google.com/service-infrastructure/docs/create-services#undeleting., failedPrecondition
│ 
│   with google_endpoints_service.endpoints_service["global-game-us-central1-02"],
│   on allocation-endpoint.tf line 15, in resource "google_endpoints_service" "endpoints_service":
│   15: resource "google_endpoints_service" "endpoints_service" {
```