### PR TITLE
Remove cleanup Job from Helm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once you have Google Cloud CLI installed, you will need to authenticate against 
 gcloud auth application-default login
 ```
 
-and then set your Google Cloud Project project name/PROJECT_ID:
+and then set your Google Cloud Project to name/PROJECT_ID:
 
 ```shell
 gcloud config set project <PROJECT_ID>
@@ -40,7 +40,7 @@ export GAME_DEMO_HOME=$(pwd)
 
 ### Provision
 
-Initialize Terraform  & configure variables
+Initialize Terraform & configure variables
 
 ```shell
 cd $GAME_DEMO_HOME/infrastructure

--- a/infrastructure/files/agones/ae-lb-ip-patch.yaml.tpl
+++ b/infrastructure/files/agones/ae-lb-ip-patch.yaml.tpl
@@ -1,82 +1,81 @@
 helmCharts:
-- name: agones
-  repo: https://agones.dev/chart/stable
-  version: 1.29.0
-  releaseName: my-agones
-  namespace: agones-system
-  valuesInline:
-    agones:
-      allocator:
-        disableMTLS: true
-        disableTLS: true
-        service:
-          serviceType: ClusterIP
+  - name: agones
+    repo: https://agones.dev/chart/stable
+    version: 1.29.0
+    releaseName: agones
+    namespace: agones-system
+    valuesInline:
+      agones:
+        crds:
+          cleanupOnDelete: false
+        allocator:
+          disableMTLS: true
+          disableTLS: true
+          service:
+            serviceType: ClusterIP
           http:
             port: 443
             targetPort: 9443
           grpc:
             enabled: false
-          loadBalancerIP: "${lb_ip}"
+            loadBalancerIP: "${lb_ip}"
 
 resources:
-- agones-system.yaml
+  - agones-system.yaml
 
 patches:
-- target:
-    kind: Service
-    name: agones-allocator
-  patch: |-
-    apiVersion: v1
-    kind: Service
-    metadata:
+  - target:
+      kind: Service
       name: agones-allocator
-      namespace: agones-system
-    spec:
-      ports:
-      - name: https
-        port: 443
-        targetPort: 9443      
-      selector:
-        $patch: replace
-
-
-- target:
-    kind: ServiceAccount
-    name: agones-allocator
-  patch: |-
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      annotations:
-        iam.gke.io/gcp-service-account: ${sa_email}
+    patch: |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: agones-allocator
+        namespace: agones-system
+      spec:
+        ports:
+        - name: https
+          port: 443
+          targetPort: 9443
+        selector:
+          $patch: replace
+  - target:
+      kind: ServiceAccount
       name: agones-allocator
-      namespace: agones-system
-
-- target:
-    kind: Deployment
-    name: agones-allocator
-  patch: |-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
+    patch: |-
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        annotations:
+          iam.gke.io/gcp-service-account: ${sa_email}
+        name: agones-allocator
+        namespace: agones-system
+  - target:
+      kind: Deployment
       name: agones-allocator
-      namespace: agones-system
-    spec:
-      template:
-        metadata:
-          labels:
-            istio.io/rev: asm-managed  #ASM managed dataplane channel
-            region: ${location}        #Region to identify the POD and send traffic
-        spec:
-          containers:
-          - args:
-            - --listener_port=9443
-            - --generate_self_signed_cert
-            - --backend=grpc://127.0.0.1:8443
-            - --service=${service_name}
-            - --rollout_strategy=managed
-            image: gcr.io/endpoints-release/endpoints-runtime:2
-            imagePullPolicy: IfNotPresent
-            name: esp
-            ports:
-            - containerPort: 9443
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: agones-allocator
+        namespace: agones-system
+      spec:
+        template:
+          metadata:
+            labels:
+              istio.io/rev: asm-managed  #ASM managed dataplane channel
+              region: ${location}        #Region to identify the POD and send traffic
+          spec:
+            containers:
+            - args:
+              - --listener_port=9443
+              - --generate_self_signed_cert
+              - --backend=grpc://127.0.0.1:8443
+              - --service=${service_name}
+              - --rollout_strategy=managed
+              image: gcr.io/endpoints-release/endpoints-runtime:2
+              imagePullPolicy: IfNotPresent
+              name: esp
+              ports:
+              - containerPort: 9443

--- a/platform/agones/install/cloudbuild.yaml
+++ b/platform/agones/install/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
     entrypoint: gcloud
     args:
       [
-        "deploy", "releases", "create", "agones-${_RELEASE_NAME}",
+        "deploy", "releases", "create", "${_RELEASE_NAME}",
         "--delivery-pipeline", "agones-deploy-pipeline",
         "--skaffold-file", "skaffold.yaml",
         "--skaffold-version", "1.39",


### PR DESCRIPTION
This means you can redeploy Agones on top of an existing Agones install.

Some notes:
* I changed the release name to "agones", so if you have Agones installed, you will need to delete the existing Deployments in the `agones-system` namespace
* Formatted the yaml.
* Dropped in some minor cleanup items.
* Removed the "agones" prefix to the release name, since redundant, and also it fixes a bugs in the docs.