### PR TITLE
Move org policies to their own directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ gcloud config set project ${PROJECT_ID}
 and then authenticate to generate [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) that can be leveraged by Terraform
 ```shell
 gcloud auth application-default login
-gcloud auth application-default set-quota-project ${PROJECT_ID}
 ```
 
 Clone this directory locally and, we'll also set an environment variable to it's root directory, for easy navigation:
@@ -40,6 +39,34 @@ export GAME_DEMO_HOME=$(pwd)
 ```
 
 ## Provision
+
+### Optional: Apply Organisational Policies
+
+You can skip this step if you are running a standard Google Cloud project, without any 
+[Organisational Policies](https://cloud.google.com/resource-manager/docs/organization-policy/overview).
+
+For convenience’s sake, we've provided the appropriate organisational level policies, applied at the project level that
+can be applied to your project, if you are running into permission issues.
+
+To apply them:
+
+```shell
+gcloud auth application-default set-quota-project ${PROJECT_ID}
+# Enable API and wait a few minutes. It can take a while for the cloudresourcemanager.googleapis.com API to propagate
+cd $GAME_DEMO_HOME/org-policy
+terraform init
+cp terraform.tfvars.sample terraform.tfvars
+```
+
+You will need to now edit `terraform.tfvars`
+
+* Update <PROJECT_ID> with the ID of your Google Cloud Project,
+
+Now run the following to apply the organisational policies to your project.
+
+```shell
+terraform apply
+```
 
 ### Optional: GCS Backend
 

--- a/infrastructure/terraform.tfvars.sample
+++ b/infrastructure/terraform.tfvars.sample
@@ -18,8 +18,6 @@
 project            = "PROJECT_ID"
 resource_env_label = "demo-global-game"
 
-apply_org_policies = false
-
 # Cloud Deploy Configuration
 platform_directory = "../platform" # Relative to Terraform directory
 services_directory = "../services" # Relative to Terraform directory

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-### Organziation Variables ###
-
-variable "apply_org_policies" {
-  type        = bool
-  description = "Boolean used to determine whether GCP Org Policies are applied"
-}
-
 ### Project Variables ###
 
 variable "project" {

--- a/org-policy/org-policies.tf
+++ b/org-policy/org-policies.tf
@@ -1,10 +1,23 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 # Optionally apply these Org Policies, as specified in terraform.tfvars file
 
 module "gcp_org_policy_v2_requireShieldedVm" {
-  source           = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
-  version          = "~> 5.2.0"
+  source  = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
+  version = "~> 5.2.0"
 
-  count          = var.apply_org_policies == true ? 1 : 0
   policy_root    = "project"
   policy_root_id = var.project
   rules = [{
@@ -18,10 +31,9 @@ module "gcp_org_policy_v2_requireShieldedVm" {
 }
 
 module "gcp_org_policy_v2_disableServiceAccountKeyCreation" {
-  source           = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
-  version          = "~> 5.2.0"
+  source  = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
+  version = "~> 5.2.0"
 
-  count          = var.apply_org_policies == true ? 1 : 0
   policy_root    = "project"
   policy_root_id = var.project
   rules = [{
@@ -35,10 +47,9 @@ module "gcp_org_policy_v2_disableServiceAccountKeyCreation" {
 }
 
 module "gcp_org_policy_v2_vmCanIpForward" {
-  source           = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
-  version          = "~> 5.2.0"
+  source  = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
+  version = "~> 5.2.0"
 
-  count          = var.apply_org_policies == true ? 1 : 0
   policy_root    = "project"
   policy_root_id = var.project
   rules = [{
@@ -52,10 +63,9 @@ module "gcp_org_policy_v2_vmCanIpForward" {
 }
 
 module "gcp_org_policy_v2_vmExternalIpAccess" {
-  source           = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
-  version          = "~> 5.2.0"
+  source  = "terraform-google-modules/org-policy/google//modules/org_policy_v2"
+  version = "~> 5.2.0"
 
-  count          = var.apply_org_policies == true ? 1 : 0
   policy_root    = "project"
   policy_root_id = var.project
   rules = [{

--- a/org-policy/project.tf
+++ b/org-policy/project.tf
@@ -1,0 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+data "google_project" "project" {
+}

--- a/org-policy/terraform.tfvars.sample
+++ b/org-policy/terraform.tfvars.sample
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "google" {
-  project = var.project
-}
 
-data "google_client_config" "provider" {}
+# Project Specific Variables
+
+project = "PROJECT_ID"

--- a/org-policy/variables.tf
+++ b/org-policy/variables.tf
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "google" {
-  project = var.project
-}
+### Project Variables ###
 
-data "google_client_config" "provider" {}
+variable "project" {
+  type        = string
+  description = "GCP Project Name"
+}


### PR DESCRIPTION
This means we don't have the extra API requirement (which take a long time to propagate?), and can mark it as an optional step on our README, which can be skipped over for most (?) of our end users.