### PR TITLE
Cleanup: Extra API dependencies.

### DIFF
--- a/infrastructure/agones-gke.tf
+++ b/infrastructure/agones-gke.tf
@@ -86,6 +86,8 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${data.google_container_cluster.game-demo-agones[each.key].id}"
     }
   }
+
+  depends_on = [google_project_service.project]
 }
 
 resource "google_gke_hub_feature" "mesh" {
@@ -93,6 +95,8 @@ resource "google_gke_hub_feature" "mesh" {
   project  = var.project
   location = "global"
   provider = google-beta
+
+  depends_on = [google_project_service.project]
 }
 
 resource "google_compute_firewall" "agones-gameservers" {

--- a/infrastructure/artifact-registry.tf
+++ b/infrastructure/artifact-registry.tf
@@ -21,4 +21,6 @@ resource "google_artifact_registry_repository" "container_registry" {
   labels = {
     "environment" = var.resource_env_label
   }
+
+  depends_on = [google_project_service.project]
 }

--- a/infrastructure/providers.tf
+++ b/infrastructure/providers.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 provider "google" {
-  project                             = var.project
+  project = var.project
 }
 
 provider "google-beta" {


### PR DESCRIPTION
Just adding `depends_on = [google_project_service.project]` so we can wait for API's to be ready before moving forward.

Work on #107