### PR TITLE
Wire the frontend to Open Match, change /play to POST with latencies

### DIFF
--- a/services/frontend/go.mod
+++ b/services/frontend/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/joho/godotenv v1.5.1
 	golang.org/x/oauth2 v0.4.0
+	google.golang.org/grpc v1.51.0
+	open-match.dev/open-match v1.7.0
 )
 
 require (
@@ -20,6 +22,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.2 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
@@ -35,6 +38,7 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/services/frontend/go.sum
+++ b/services/frontend/go.sum
@@ -26,6 +26,7 @@ github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
@@ -33,6 +34,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -94,6 +97,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 h1:jmIfw8+gSvXcZSgaFAGyInDXeWzUhvYH57G/5GKMn70=
+google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/grpc v1.51.0 h1:E1eGv1FTqoLIdnBCZufiSHgKjlqG6fKFf6pPWtMTh8U=
+google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
@@ -103,4 +110,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+open-match.dev/open-match v1.7.0 h1:EzPPzsMy92i52XNrRWx3KMXIcNzdgHwMd01KsoT7HaI=
+open-match.dev/open-match v1.7.0/go.mod h1:JAkoEIVgc8p6GnfpxOC5Aqby2vkQDHrjlCbI2crP3WU=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/services/frontend/match/match.go
+++ b/services/frontend/match/match.go
@@ -1,0 +1,116 @@
+// Copyright 2023 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Match creates/watches Open Match tickets for a PlayRequest
+package match
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc"
+	om "open-match.dev/open-match/pkg/pb"
+
+	"github.com/googleforgames/global-multiplayer-demo/services/frontend-api/models"
+)
+
+const (
+	// The endpoint for the Open Match Frontend service.
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
+)
+
+// Matcher interfaces with Open Match to create a ticket and watch for an assignment.
+type Matcher struct {
+	conn   *grpc.ClientConn
+	client om.FrontendServiceClient
+}
+
+// NewMatcher returns a new Matcher. Close() should be deferred after a successful return.
+func NewMatcher() (*Matcher, error) {
+	conn, err := grpc.Dial(omFrontendEndpoint, grpc.WithInsecure())
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Open Match: %w", err)
+	}
+	return &Matcher{client: om.NewFrontendServiceClient(conn)}, nil
+}
+
+// Close releases any resources of the Matcher.
+func (m *Matcher) Close() {
+	m.conn.Close()
+}
+
+// FindMatchingServer takes a PlayRequest, constructs an Open Match ticket, and waits for an assignment.
+func (m *Matcher) FindMatchingServer(ctx context.Context, pr *models.PlayRequest) (*models.OMServerResponse, error) {
+	log.Printf("Creating Open Match ticket for /play request: %#v", pr)
+
+	req := &om.CreateTicketRequest{
+		Ticket: makeTicket(pr),
+	}
+	resp, err := m.client.CreateTicket(ctx, req)
+	if err != nil {
+		log.Printf("CreateTicket failed for ticket %#v: %v", req.Ticket, err)
+		return nil, fmt.Errorf("CreateTicket failed: %w", err)
+	}
+	tid := resp.Id
+	log.Printf("Ticket %s: created: %v", tid, req.Ticket)
+
+	stream, err := m.client.WatchAssignments(ctx, &om.WatchAssignmentsRequest{TicketId: tid})
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			log.Printf("Ticket %s: WatchAssignments failed: %v", tid, err)
+			return nil, fmt.Errorf("WatchAssignments failed: %w", err)
+		}
+
+		omsr, err := hostPortToModel(resp.Assignment.Connection)
+		if err != nil {
+			log.Printf("Ticket %s: can't parse connection: %v", tid, err)
+			return nil, fmt.Errorf("can't parse connection: %w", err)
+		}
+		return omsr, nil
+	}
+}
+
+func hostPortToModel(hostPort string) (*models.OMServerResponse, error) {
+	pieces := strings.Split(hostPort, ":")
+	if len(pieces) != 2 {
+		return nil, fmt.Errorf("host:port %q has %d pieces, want 2", hostPort, len(pieces))
+	}
+	port, err := strconv.Atoi(pieces[1])
+	if err != nil {
+		return nil, fmt.Errorf("can't parse port of host:port %q as int: %w", hostPort, err)
+	}
+	return &models.OMServerResponse{
+		IP:   pieces[0],
+		Port: port,
+	}, nil
+}
+
+func makeTicket(pr *models.PlayRequest) *om.Ticket {
+	t := &om.Ticket{
+		SearchFields: &om.SearchFields{
+			DoubleArgs: map[string]float64{
+				"skill": 0.0, // TODO: Add skill!
+			},
+		},
+	}
+	// TODO: validate against known regions
+	for region, ping := range pr.PingByRegion {
+		t.SearchFields.DoubleArgs["latency-"+region] = float64(ping)
+	}
+	return t
+}

--- a/services/frontend/models/server.go
+++ b/services/frontend/models/server.go
@@ -14,8 +14,6 @@
 
 package models
 
-import "log"
-
 type OMServerResponse struct {
 	IP   string
 	Port int
@@ -30,16 +28,6 @@ type PingServer struct {
 	Port      uint64
 }
 
-func FindMatchingServer(region string) OMServerResponse {
-
-	// TODO: Query OpenMatch on `OMFrontendEndpoint` in a preferred region for a server
-	log.Printf("Looking for a server in the %s region.\n", region)
-
-	IP := "127.0.0.1"
-	Port := 7777
-
-	return OMServerResponse{
-		IP:   IP,
-		Port: Port}
-
+type PlayRequest struct {
+	PingByRegion map[string]int32 `json:"pingByRegion"` // region -> ping time in milliseconds
 }


### PR DESCRIPTION
* Changes the /play API to the following structure, vs a single latency:

```
type PlayRequest struct {
    PingByRegion map[string]int32 `json:"pingByRegion"` // region -> ping time in milliseconds
}
```

* Changes /play to a POST
* Wires the /play method to the Open Match ticket format from #135. The client uses the watch function (which is better than the polling the fake frontend does), cribbed-ish from:
  https://github.com/googleforgames/open-match/blob/main/examples/demo/components/clients/clients.go

Tested with the _*super advanced*_:

```
for i in {1..4}; do 
  curl -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" --data '{"pingByRegion":{"us-central1":50, "europe-west1":100, "asia-east1":150}}' http://35.238.207.159.sslip.io/play &
done
```