### PR TITLE
Add tolerateFailuresUntilDeadline to services and open-match skaffold

### DIFF
--- a/platform/cloudbuild.yaml
+++ b/platform/cloudbuild.yaml
@@ -47,7 +47,6 @@ steps:
         "deploy", "releases", "create", "open-match-${_RELEASE_NAME}",
         "--delivery-pipeline", "global-game-open-match",
         "--skaffold-file", "skaffold.yaml",
-        "--skaffold-version", "1.39",
         "--region", "us-central1"
       ]
 

--- a/platform/open-match/skaffold.yaml
+++ b/platform/open-match/skaffold.yaml
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta29
+apiVersion: skaffold/v4beta1
 kind: Config
-deploy:
+manifests:
   kustomize:
     paths:
-      - "./base"
-    buildArgs: ["--enable-helm"]
+      - ./base
+    buildArgs:
+      - --enable-helm
+deploy:
+  kubectl:
     flags:
-      apply: ['--server-side', '--force-conflicts'] # Avoid the "Too long: must have at most 262144 bytes" problem
+      apply:
+        - --server-side # Avoid the "Too long: must have at most 262144 bytes" problem
+        - --force-conflicts
+  tolerateFailuresUntilDeadline: true # Fixes startup timeouts

--- a/services/cloudbuild.yaml
+++ b/services/cloudbuild.yaml
@@ -62,7 +62,6 @@ steps:
         "deploy", "releases", "create", "${_RELEASE_NAME}",
         "--delivery-pipeline", "global-game-services",
         "--skaffold-file", "skaffold.yaml",
-        "--skaffold-version", "1.39",
         "--images", "ping-discovery=${_PING_IMAGE},profile=${_PROFILE_IMAGE},frontend=${_FRONTEND_IMAGE},open-match-director=${_OPEN_MATCH_DIRECTOR_IMAGE},open-match-matchfunction=${_OPEN_MATCH_MATCHFUNCTION_IMAGE},open-match-fake-frontend=${_OPEN_MATCH_FAKE_FRONTEND_IMAGE}",
         "--region", "us-central1"
       ]

--- a/services/skaffold.yaml
+++ b/services/skaffold.yaml
@@ -12,17 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta29
+apiVersion: skaffold/v4beta1
 kind: Config
+manifests:
+  rawYaml:
+    - ping-discovery/service-account.yaml
+    - ping-discovery/deployment.yaml
+    - profile/spanner_config.yaml
+    - profile/deployment.yaml
+    - frontend/config.yaml
+    - frontend/deployment.yaml
+    - open-match/director/director.yaml
+    - open-match/matchfunction/matchfunction.yaml
+    - open-match/fake-frontend/fake-frontend.yaml
 deploy:
   kubectl:
-    manifests:
-      - ping-discovery/service-account.yaml
-      - ping-discovery/deployment.yaml
-      - profile/spanner_config.yaml
-      - profile/deployment.yaml
-      - frontend/config.yaml
-      - frontend/deployment.yaml
-      - open-match/director/director.yaml
-      - open-match/matchfunction/matchfunction.yaml
-      - open-match/fake-frontend/fake-frontend.yaml
+    flags:
+      apply:
+        - --server-side # Avoid the "Too long: must have at most 262144 bytes" problem
+  tolerateFailuresUntilDeadline: true # Fixes startup timeouts


### PR DESCRIPTION
This PR makes the deployment options roughly consistent with https://github.com/googleforgames/global-multiplayer-demo/pull/121:
* Adds `tolerateFailuresUntilDeadline`, but that requires us to..
* Migrate to v4beta1 schema

Closes #143