### PR TITLE
Give Compute Service Account access to Artifact Repo Read role

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -50,6 +50,7 @@ resource "google_project_iam_member" "clouddeploy-iam" {
   project = var.project
   for_each = toset([
     "roles/container.admin",
+    "roles/artifactregistry.reader",
     "roles/storage.admin"
   ])
   role   = each.key


### PR DESCRIPTION
Fix to address issue #161 - adding the Artifact Repo Reader role to Compute Service Account.