### PR TITLE
Get Open Match working on K8s 1.25+

### DIFF
--- a/infrastructure/files/open-match/kustomization.yaml.tpl
+++ b/infrastructure/files/open-match/kustomization.yaml.tpl
@@ -20,6 +20,12 @@ helmCharts:
   version: 1.6.0
   releaseName: open-match
   valuesInline:
+    prometheus:
+      enabled: false
+    grafana:
+      enabled: false
+    jaeger:
+      enabled: false
     open-match-override:
       enabled: true
     open-match-customize:
@@ -42,3 +48,9 @@ helmCharts:
 resources:
   - open-match.yaml
   - agones-allocator-vs.yaml
+
+patches:
+    - path: psp/delete-core-psp.yaml
+    - path: psp/delete-redis-psp.yaml
+    - path: psp/delete-service-role.yaml
+    - path: psp/delete-service-binding.yaml

--- a/infrastructure/services-gke.tf
+++ b/infrastructure/services-gke.tf
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Pinning Services Cluster version to 1.24 until open-match supports GKE 1.25+
-data "google_container_engine_versions" "services-cluster" {
-  provider       = google
-  location       = var.services_gke_config.location
-  version_prefix = "1.24."
-}
-
 resource "google_container_cluster" "services-gke" {
-  name               = var.services_gke_config.cluster_name
-  location           = var.services_gke_config.location
-  min_master_version = data.google_container_engine_versions.services-cluster.latest_node_version
-  node_version       = data.google_container_engine_versions.services-cluster.latest_node_version
+  name     = var.services_gke_config.cluster_name
+  location = var.services_gke_config.location
 
   network    = google_compute_network.vpc.name
   subnetwork = google_compute_subnetwork.subnet[var.services_gke_config.location].name
@@ -42,22 +33,6 @@ resource "google_container_cluster" "services-gke" {
 
   resource_labels = {
     "environment" = var.resource_env_label
-  }
-
-  maintenance_policy {
-    recurring_window {
-      start_time = "2019-08-01T02:00:00Z"
-      end_time   = "2019-08-01T06:00:00Z"
-      recurrence = "FREQ=DAILY"
-    }
-    maintenance_exclusion {
-      exclusion_name = "No Upgrades"
-      start_time     = "2019-01-01T00:00:00Z"
-      end_time       = "2019-01-02T00:00:00Z"
-      exclusion_options {
-        scope = "NO_MINOR_OR_NODE_UPGRADES"
-      }
-    }
   }
 
   depends_on = [google_compute_subnetwork.subnet, google_project_service.project]

--- a/platform/open-match/base/psp/delete-core-psp.yaml
+++ b/platform/open-match/base/psp/delete-core-psp.yaml
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Namespace
+$patch: delete
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
 metadata:
-  name: open-match
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: baseline
+  name: open-match-core-podsecuritypolicy
+  namespace: open-match

--- a/platform/open-match/base/psp/delete-redis-psp.yaml
+++ b/platform/open-match/base/psp/delete-redis-psp.yaml
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Namespace
+$patch: delete
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
 metadata:
-  name: open-match
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: baseline
+  name: open-match-redis-podsecuritypolicy
+  namespace: open-match

--- a/platform/open-match/base/psp/delete-service-binding.yaml
+++ b/platform/open-match/base/psp/delete-service-binding.yaml
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Namespace
+$patch: delete
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: open-match
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: baseline
+  name: open-match-service-role-binding
+  namespace: open-match

--- a/platform/open-match/base/psp/delete-service-role.yaml
+++ b/platform/open-match/base/psp/delete-service-role.yaml
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Namespace
+$patch: delete
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  name: open-match
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/warn: baseline
+  name: open-match-service-role
+  namespace: open-match

--- a/services/open-match/director/main.go
+++ b/services/open-match/director/main.go
@@ -113,8 +113,7 @@ func fetch(be pb.BackendServiceClient, p *pb.MatchProfile) ([]*pb.Match, error) 
 
 	stream, err := be.FetchMatches(context.Background(), req)
 	if err != nil {
-		log.Println()
-		return nil, err
+		return nil, fmt.Errorf("error on fetch match request from backend: %w", err)
 	}
 
 	var result []*pb.Match
@@ -125,7 +124,7 @@ func fetch(be pb.BackendServiceClient, p *pb.MatchProfile) ([]*pb.Match, error) 
 		}
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error on fetch match stream recieving: %w", err)
 		}
 
 		result = append(result, resp.GetMatch())


### PR DESCRIPTION
This does the following:

* Disable all child Helm charts from Open Match install
* Backport PodSecurityPolicy removal from https://github.com/googleforgames/open-match/pull/1540 through kustomize
* Custom Director: Extra debugging.