### PR TITLE
Cloud Build: Tags and Generated release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This should give you back an IP, such as `35.202.107.204`.
 Since OAuth needs a domain to authenticate against, we'll use [sslip.io](https://sslip.io) for development purposes.
 
 #### Deploy Platform Components
-Replace the` _RELEASE_NAME` substitution with a unique build name. Cloud Build will deploy
+Cloud Build will deploy
 
 - Anthos Service Mesh (ASM) to all clusters using the fleet feature API
 - Agones using Cloud Deploy
@@ -193,7 +193,7 @@ Replace the` _RELEASE_NAME` substitution with a unique build name. Cloud Build w
 
 ```shell
 cd $GAME_DEMO_HOME/platform/
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
+gcloud builds submit --config=cloudbuild.yaml
 ```
 
 Navigate to the
@@ -203,7 +203,7 @@ deploys Agones the first game server cluster. Agones can be deployed to subseque
 `promote` button within the Pipeline visualization or by running the following gcloud command:
 
 ```shell
-## Replace RELEASE_NAME with the unique build name
+## Replace RELEASE_NAME with the unique id generated from the Cloud Build.
 gcloud deploy releases promote --release=RELEASE_NAME --delivery-pipeline=agones-deploy-pipeline --region=us-central1
 ```
 
@@ -225,12 +225,11 @@ This will deploy the schema migration using [Liquibase](https://www.liquibase.or
 
 ### Install Game Backend Services
 
-To install all the backend services, submit the following Cloud Build command, and replace the` _RELEASE_NAME`
-substitution with a unique build name.
+To install all the backend services, submit the following Cloud Build command.
 
 ```shell
 cd $GAME_DEMO_HOME/services
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
+gcloud builds submit --config=cloudbuild.yaml
 ```
 
 This will:
@@ -241,12 +240,11 @@ This will:
 
 ### Dedicated Game Server
 
-To build the Unreal dedicated game server image, run the following command, and replace the` _RELEASE_NAME`
-substitution with a unique build name.
+To build the Unreal dedicated game server image, run the following command.
 
 ```shell
 cd $GAME_DEMO_HOME/game
-gcloud builds submit --config=cloudbuild.yaml --substitutions=_RELEASE_NAME=rel-1
+gcloud builds submit --config=cloudbuild.yaml
 ```
 
 Cloud Build will deploy:

--- a/game/cloudbuild.yaml
+++ b/game/cloudbuild.yaml
@@ -35,15 +35,16 @@ steps:
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: cloud-deploy-release
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      [
-        "deploy", "releases", "create", "${_RELEASE_NAME}",
-        "--delivery-pipeline", "global-game-agones-gameservers",
-        "--skaffold-file", "skaffold.yaml",
-        "--images", "droidshooter-server=${_UNREAL_SERVER_IMAGE}",
-        "--region", "us-central1"
-      ]
+      - "-c"
+      - |
+        gcloud deploy releases create deploy-$(date +'%Y%m%d%H%M%S') \
+        --annotations=cloud_build=https://console.cloud.google.com/cloud-build/builds/${BUILD_ID} \
+        --delivery-pipeline global-game-agones-gameservers \
+        --skaffold-file skaffold.yaml \
+        --images droidshooter-server=${_UNREAL_SERVER_IMAGE} \
+        --region us-central1
 
 artifacts:
   images:
@@ -51,7 +52,6 @@ artifacts:
 substitutions:
   _UNREAL_SERVER_IMAGE: ${_REGISTRY}/droidshooter-server:${BUILD_ID}
   _REGISTRY: us-docker.pkg.dev/${PROJECT_ID}/global-game-images
-  _RELEASE_NAME: rel-01
 availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/github-packages/versions/latest
@@ -60,3 +60,6 @@ options:
   dynamic_substitutions: true
   machineType: E2_HIGHCPU_32
   logging: CLOUD_LOGGING_ONLY
+tags:
+  - global-game-demo
+  - game

--- a/infrastructure/files/agones/agones-install.yaml.tpl
+++ b/infrastructure/files/agones/agones-install.yaml.tpl
@@ -1,14 +1,13 @@
 helmCharts:
   - name: agones
     repo: https://agones.dev/chart/stable
-    version: 1.30.0
+    version: 1.32.0
     releaseName: agones
     namespace: agones-system
     valuesInline:
       agones:
         crds:
           cleanupOnDelete: false
-        featureGates: "SplitControllerAndExtensions=true"
         allocator:
           disableMTLS: true
           disableTLS: true

--- a/infrastructure/schema/cloudbuild.yaml
+++ b/infrastructure/schema/cloudbuild.yaml
@@ -39,3 +39,6 @@ artifacts:
 options:
   dynamic_substitutions: true
   logging: CLOUD_LOGGING_ONLY
+tags:
+  - global-game-demo
+  - infrastructure/schema

--- a/platform/cloudbuild.yaml
+++ b/platform/cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
   # support for ASM at cluster creation time, this step is performed with platform component deployments so
   # newly added clusters are configured properly with ASM.
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: fleet-membership
     entrypoint: bash
     args:
     - '-c'
@@ -28,29 +29,38 @@ steps:
         gcloud container fleet mesh update --management automatic --memberships $$MEMBERSHIPS
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    id: deploy-agones
+    entrypoint: bash
     dir: agones
     args:
-      [
-        "deploy", "releases", "create", "${_RELEASE_NAME}",
-        "--delivery-pipeline", "agones-deploy-pipeline",
-        "--skaffold-file", "skaffold.yaml",
-        "--region", "us-central1"
-      ]
-    timeout: 1800s
+      - '-c'
+      - |
+        gcloud deploy releases create deploy-$(date +'%Y%m%d%H%M%S') \
+        --annotations=cloud_build=https://console.cloud.google.com/cloud-build/builds/${BUILD_ID} \
+        --delivery-pipeline agones-deploy-pipeline \
+        --skaffold-file skaffold.yaml \
+        --region us-central1
+    waitFor:
+      - fleet-membership
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    id: deploy-open-match
+    entrypoint: bash
     dir: open-match
     args:
-      [
-        "deploy", "releases", "create", "open-match-${_RELEASE_NAME}",
-        "--delivery-pipeline", "global-game-open-match",
-        "--skaffold-file", "skaffold.yaml",
-        "--region", "us-central1"
-      ]
+      - '-c'
+      - |
+        gcloud deploy releases create deploy-$(date +'%Y%m%d%H%M%S') \
+        --annotations=cloud_build=https://console.cloud.google.com/cloud-build/builds/${BUILD_ID} \
+        --delivery-pipeline global-game-open-match \
+        --skaffold-file skaffold.yaml \
+        --region us-central1
+    waitFor:
+      - fleet-membership
 
-substitutions:
-  _RELEASE_NAME: rel-0001
 options:
+  dynamic_substitutions: true
   logging: CLOUD_LOGGING_ONLY
+tags:
+  - global-game-demo
+  - platform

--- a/services/cloudbuild.yaml
+++ b/services/cloudbuild.yaml
@@ -56,15 +56,16 @@ steps:
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: cloud-deploy-release
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      [
-        "deploy", "releases", "create", "${_RELEASE_NAME}",
-        "--delivery-pipeline", "global-game-services",
-        "--skaffold-file", "skaffold.yaml",
-        "--images", "ping-discovery=${_PING_IMAGE},profile=${_PROFILE_IMAGE},frontend=${_FRONTEND_IMAGE},open-match-director=${_OPEN_MATCH_DIRECTOR_IMAGE},open-match-matchfunction=${_OPEN_MATCH_MATCHFUNCTION_IMAGE},open-match-fake-frontend=${_OPEN_MATCH_FAKE_FRONTEND_IMAGE}",
-        "--region", "us-central1"
-      ]
+      - "-c"
+      - |
+        gcloud deploy releases create deploy-$(date +'%Y%m%d%H%M%S') \
+        --annotations=cloud_build=https://console.cloud.google.com/cloud-build/builds/${BUILD_ID} \
+        --delivery-pipeline global-game-services \
+        --skaffold-file skaffold.yaml \
+        --images ping-discovery=${_PING_IMAGE},profile=${_PROFILE_IMAGE},frontend=${_FRONTEND_IMAGE},open-match-director=${_OPEN_MATCH_DIRECTOR_IMAGE},open-match-matchfunction=${_OPEN_MATCH_MATCHFUNCTION_IMAGE},open-match-fake-frontend=${_OPEN_MATCH_FAKE_FRONTEND_IMAGE} \
+        --region us-central1
 
 artifacts:
   images:
@@ -82,8 +83,10 @@ substitutions:
   _OPEN_MATCH_MATCHFUNCTION_IMAGE: ${_REGISTRY}/open-match-matchfunction:${BUILD_ID}
   _OPEN_MATCH_FAKE_FRONTEND_IMAGE: ${_REGISTRY}/open-match-fake-frontend:${BUILD_ID}
   _REGISTRY: us-docker.pkg.dev/${PROJECT_ID}/global-game-images
-  _RELEASE_NAME: rel-01
 options:
   dynamic_substitutions: true
   machineType: E2_HIGHCPU_8
   logging: CLOUD_LOGGING_ONLY
+tags:
+  - global-game-demo
+  - services


### PR DESCRIPTION
This PR does several things:

* Add descriptive tags to all Cloud Build pipelines, so you can tell what build is what.
* Generates a Cloud Deploy release name from the current date and time. Note: We didn't use the Cloud Build id as it would cause too long a resource name on rollouts, and would therefore fail.
* Add the link to the Cloud Build to the Deployment release annotations
  - which as a fancy trick is clickable in the Cloud Console!

Closes #104
Closes #156

I also found that the Agones installed version wasn't upgraded to 1.32.0 which broke on the later versions of Autopilot, so I upgraded that version as well while I was in there.

Aren't all these tags nice? 😄 
![image](https://github.com/googleforgames/global-multiplayer-demo/assets/298370/bac011cc-6993-4225-b94a-9e0742c17e3b)
