### PR TITLE
Upgrade Agones to v1.34

### DIFF
--- a/infrastructure/agones-gke.tf
+++ b/infrastructure/agones-gke.tf
@@ -25,7 +25,7 @@ data "google_container_engine_versions" "regions" {
 module "agones_gke_standard_clusters" {
   for_each = var.game_gke_standard_clusters
 
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=v1.32.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=v1.34.0"
 
   cluster = {
     name             = each.key
@@ -49,7 +49,7 @@ module "agones_gke_standard_clusters" {
 module "agones_gke_autopilot_clusters" {
   for_each = var.game_gke_autopilot_clusters
 
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke-autopilot/?ref=v1.32.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke-autopilot/?ref=v1.34.0"
 
   cluster = {
     name     = each.key

--- a/infrastructure/files/agones/agones-install.yaml.tpl
+++ b/infrastructure/files/agones/agones-install.yaml.tpl
@@ -1,7 +1,7 @@
 helmCharts:
   - name: agones
     repo: https://agones.dev/chart/stable
-    version: 1.32.0
+    version: 1.34.0
     releaseName: agones
     namespace: agones-system
     valuesInline:

--- a/infrastructure/services-gke.tf
+++ b/infrastructure/services-gke.tf
@@ -31,6 +31,12 @@ resource "google_container_cluster" "services-gke" {
     enable_private_endpoint = false
   }
 
+  dns_config {
+    cluster_dns        = "CLOUD_DNS"
+    cluster_dns_domain = "cluster.local"
+    cluster_dns_scope  = "CLUSTER_SCOPE"
+  }
+
   resource_labels = {
     "environment" = var.resource_env_label
   }

--- a/infrastructure/terraform.tfvars.sample
+++ b/infrastructure/terraform.tfvars.sample
@@ -84,7 +84,6 @@ gcp_project_services = [
   "cloudresourcemanager.googleapis.com",
   "compute.googleapis.com",
   "container.googleapis.com",
-  "gameservices.googleapis.com",
   "gkehub.googleapis.com",
   "meshca.googleapis.com",
   "meshconfig.googleapis.com",


### PR DESCRIPTION
Upgrade Agones to v1.34

Additional -

Removed deprecated gameservices API enablement
Added DNS Terraform config to prevent Autopilot cluster destroy & recreate.  