### PR TITLE
Add resources to Fleet spec.

### DIFF
--- a/game/fleet.yaml
+++ b/game/fleet.yaml
@@ -31,3 +31,7 @@ spec:
           containers:
             - name: droidshooter
               image: droidshooter-server
+              resources:
+                requests:
+                  cpu: 1000m
+                  memory: 1Gi


### PR DESCRIPTION
Ran into a weird issue where Autopilot was trying to guess some truly bizarre cpu and memory requirements for each GameServer Pod.

Setting it explicitly is (a) a good best practice and (b) solved the problem.