### PR TITLE
Updated Agones to use release v1.38

### DIFF
--- a/infrastructure/agones-gke.tf
+++ b/infrastructure/agones-gke.tf
@@ -25,7 +25,7 @@ data "google_container_engine_versions" "regions" {
 module "agones_gke_standard_clusters" {
   for_each = var.game_gke_standard_clusters
 
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=v1.36.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=v1.38.0"
 
   cluster = {
     name             = each.key
@@ -49,7 +49,7 @@ module "agones_gke_standard_clusters" {
 module "agones_gke_autopilot_clusters" {
   for_each = var.game_gke_autopilot_clusters
 
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke-autopilot/?ref=v1.36.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke-autopilot/?ref=v1.38.0"
 
   cluster = {
     name     = each.key

--- a/infrastructure/files/agones/agones-install.yaml.tpl
+++ b/infrastructure/files/agones/agones-install.yaml.tpl
@@ -1,7 +1,7 @@
 helmCharts:
   - name: agones
     repo: https://agones.dev/chart/stable
-    version: 1.36.0
+    version: 1.38.0
     releaseName: agones
     namespace: agones-system
     valuesInline:


### PR DESCRIPTION
Updated Agones to use release v1.38

[Agones v1.38](https://github.com/googleforgames/agones/releases/tag/v1.38.0)