### PR TITLE
Move Profile Service to Cloud Deploy Parameters

### DIFF
--- a/infrastructure/game-server.tf
+++ b/infrastructure/game-server.tf
@@ -20,7 +20,7 @@ resource "google_secret_manager_secret" "secret_github_packages" {
   }
 
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.56.0"
+      version = "5.16.0"
     }
   }
 

--- a/infrastructure/pipelines.tf
+++ b/infrastructure/pipelines.tf
@@ -48,6 +48,14 @@ resource "google_clouddeploy_delivery_pipeline" "services_pipeline" {
   serial_pipeline {
     stages {
       target_id = google_clouddeploy_target.services_deploy_target.target_id
+      deploy_parameters {
+        values = {
+          project               = var.project
+          spanner_service_email = google_service_account.spanner-sa.email
+          spanner_instance_id   = google_spanner_instance.global-game-spanner.name
+          spanner_database_id   = google_spanner_database.spanner-database.name
+        }
+      }
     }
   }
 }

--- a/infrastructure/spanner.tf
+++ b/infrastructure/spanner.tf
@@ -65,15 +65,3 @@ resource "local_file" "liquibase-properties" {
   })
   filename = "${path.module}/${var.schema_directory}/liquibase.properties"
 }
-
-# Make Config file for deploy with Cloud Deploy
-resource "local_file" "services-profile-config" {
-  content = templatefile(
-    "${path.module}/files/services/profile-service-config.yaml.tpl", {
-      service_email = google_service_account.spanner-sa.email
-      project_id    = var.project
-      instance_id   = google_spanner_instance.global-game-spanner.name
-      database_id   = google_spanner_database.spanner-database.name
-  })
-  filename = "${path.module}/${var.services_directory}/profile/spanner_config.yaml"
-}

--- a/services/cloudbuild.yaml
+++ b/services/cloudbuild.yaml
@@ -15,57 +15,55 @@
 serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cloudbuild-cicd@${PROJECT_ID}.iam.gserviceaccount.com
 steps:
 
-#
-# Building of images
-#
+  #
+  # Building of images
+  #
 
   - name: gcr.io/cloud-builders/docker
     id: ping-discovery
-    args: ["build", ".", "-t", "${_PING_IMAGE}"]
+    args: [ "build", ".", "-t", "${_PING_IMAGE}" ]
     dir: ping-discovery
-    waitFor: ['-']
+    waitFor: [ '-' ]
   - name: gcr.io/cloud-builders/docker
     id: profile
-    args: ["build", ".", "-t", "${_PROFILE_IMAGE}"]
+    args: [ "build", ".", "-t", "${_PROFILE_IMAGE}" ]
     dir: profile
-    waitFor: ['-']
+    waitFor: [ '-' ]
   - name: gcr.io/cloud-builders/docker
     id: frontend
-    args: ["build", ".", "-t", "${_FRONTEND_IMAGE}"]
+    args: [ "build", ".", "-t", "${_FRONTEND_IMAGE}" ]
     dir: frontend
-    waitFor: ['-']
+    waitFor: [ '-' ]
   - name: gcr.io/cloud-builders/docker
     id: open-match-director
-    args: ["build", ".", "-t", "${_OPEN_MATCH_DIRECTOR_IMAGE}"]
+    args: [ "build", ".", "-t", "${_OPEN_MATCH_DIRECTOR_IMAGE}" ]
     dir: open-match/director
-    waitFor: ['-']
+    waitFor: [ '-' ]
   - name: gcr.io/cloud-builders/docker
     id: open-match-matchfunction
-    args: ["build", ".", "-t", "${_OPEN_MATCH_MATCHFUNCTION_IMAGE}"]
+    args: [ "build", ".", "-t", "${_OPEN_MATCH_MATCHFUNCTION_IMAGE}" ]
     dir: open-match/matchfunction
-    waitFor: ['-']
+    waitFor: [ '-' ]
   - name: gcr.io/cloud-builders/docker
     id: open-match-fake-frontend
-    args: ["build", ".", "-t", "${_OPEN_MATCH_FAKE_FRONTEND_IMAGE}"]
+    args: [ "build", ".", "-t", "${_OPEN_MATCH_FAKE_FRONTEND_IMAGE}" ]
     dir: open-match/fake-frontend
-    waitFor: ['-']
+    waitFor: [ '-' ]
 
-#
-# Deployment
-#
+  #
+  # Deployment
+  #
 
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
     id: cloud-deploy-release
-    entrypoint: bash
-    args:
-      - "-c"
-      - |
-        gcloud deploy releases create deploy-$(date +'%Y%m%d%H%M%S') \
-        --annotations=cloud_build=https://console.cloud.google.com/cloud-build/builds/${BUILD_ID} \
-        --delivery-pipeline global-game-services \
-        --skaffold-file skaffold.yaml \
-        --images ping-discovery=${_PING_IMAGE},profile=${_PROFILE_IMAGE},frontend=${_FRONTEND_IMAGE},open-match-director=${_OPEN_MATCH_DIRECTOR_IMAGE},open-match-matchfunction=${_OPEN_MATCH_MATCHFUNCTION_IMAGE},open-match-fake-frontend=${_OPEN_MATCH_FAKE_FRONTEND_IMAGE} \
-        --region us-central1
+    script: |
+      gcloud deploy releases create deploy-$(date +'%Y%m%d%H%M%S') \
+      --annotations=cloud_build=https://console.cloud.google.com/cloud-build/builds/$BUILD_ID \
+      --delivery-pipeline global-game-services \
+      --skaffold-file skaffold.yaml \
+      --images ping-discovery=$_PING_IMAGE,profile=$_PROFILE_IMAGE,frontend=$_FRONTEND_IMAGE,open-match-director=$_OPEN_MATCH_DIRECTOR_IMAGE,open-match-matchfunction=$_OPEN_MATCH_MATCHFUNCTION_IMAGE,open-match-fake-frontend=$_OPEN_MATCH_FAKE_FRONTEND_IMAGE \
+      --region us-central1
+    automapSubstitutions: true
 
 artifacts:
   images:

--- a/services/profile/.gitignore
+++ b/services/profile/.gitignore
@@ -16,4 +16,3 @@ config.yml
 test_data/***
 vendor/***
 bin/***
-spanner_config.yaml

--- a/services/profile/spanner-config.yaml
+++ b/services/profile/spanner-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC All Rights Reserved.
+# Copyright 2024 Google LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: profile
   annotations:
-    iam.gke.io/gcp-service-account: ${service_email}
+    iam.gke.io/gcp-service-account: spanner-sa@project.iam.gserviceaccount.com # from-param: ${spanner_service_email}
 
 ---
 
@@ -26,6 +26,6 @@ kind: ConfigMap
 metadata:
   name: spanner-config
 data:
-  SPANNER_PROJECT_ID: ${project_id}
-  SPANNER_INSTANCE_ID: ${instance_id}
-  SPANNER_DATABASE_ID: ${database_id}
+  SPANNER_PROJECT_ID: "project" # from-param: ${project}
+  SPANNER_INSTANCE_ID: "instance_id" # from-param: ${spanner_instance_id}
+  SPANNER_DATABASE_ID: "database_id" # from-param: ${spanner_database_id}

--- a/services/skaffold.yaml
+++ b/services/skaffold.yaml
@@ -18,7 +18,7 @@ manifests:
   rawYaml:
     - ping-discovery/service-account.yaml
     - ping-discovery/deployment.yaml
-    - profile/spanner_config.yaml
+    - profile/spanner-config.yaml
     - profile/deployment.yaml
     - frontend/config.yaml
     - frontend/deployment.yaml


### PR DESCRIPTION
Starting the work to move our Service Cloud Deploy configuration away from files generated from Terraform, to using Cloud Deploy Parameters!

So the Teraform now stores the required information on the Cloud Deploy Pipeline that needs to be used in Parameters - and Cloud Deploy handles the rest! It's pretty straight forward, and requires minimal code changes.

Included some other minor tweaks:
* Switch to use a script step.
* Formatted the cloud build script
* Needed to upgrade the Google Cloud Terraform module

More services coming!

Work on #181