### PR TITLE
Move liquidbase.properties off local machine.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ platform/agones/skaffold.yaml
 **/global-game-*/agones-system.yaml
 platform/open-match/base/kustomization.yaml
 
-# Ignore Terraform generated liquibase files
-infrastructure/schema/liquibase.properties
+# Ignore any tmp files generated
+infrastructure/tmp
 
 # Ignore go.work, go.work.sum (results of `go work`)
 go.work

--- a/infrastructure/schema/cloudbuild.yaml
+++ b/infrastructure/schema/cloudbuild.yaml
@@ -15,6 +15,10 @@
 serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cloudbuild-cicd@${PROJECT_ID}.iam.gserviceaccount.com
 steps:
 
+  - name: gcr.io/cloud-builders/gcloud
+    id: download schema file
+    args: ["storage", "cp", "gs://${PROJECT_ID}-spanner-schema/liquibase.properties", "."]
+
   #
   # Building of schema image
   #

--- a/infrastructure/spanner.tf
+++ b/infrastructure/spanner.tf
@@ -63,5 +63,17 @@ resource "local_file" "liquibase-properties" {
       instance_id = google_spanner_instance.global-game-spanner.name
       database_id = google_spanner_database.spanner-database.name
   })
-  filename = "${path.module}/${var.schema_directory}/liquibase.properties"
+  filename = "${path.module}/tmp/liquibase.properties"
+}
+
+# Store the file in GCS as our source of truth for where our database is.
+resource "google_storage_bucket" "spanner-schema" {
+  location = "US"
+  name     = "${var.project}-spanner-schema"
+}
+
+resource "google_storage_bucket_object" "upload-spanner-schema" {
+  name   = "liquibase.properties"
+  bucket = google_storage_bucket.spanner-schema.name
+  source = local_file.liquibase-properties.filename
 }


### PR DESCRIPTION
This moves the liquidbase.properties file into a GCS bucket, so it's referencable from the Cloud Build script that does the Spanner schema migration.

This moves the file off the local file system, which is a pre-requisite work for #192, and should also be done before marking #181 as complete.

To test:

```shell
cd $GAME_DEMO_HOME/infrastructure
terraform apply
cd $GAME_DEMO_HOME/infrastructure/schema
gcloud builds submit --config=cloudbuild.yaml
```

There should be no changes to the schema.
