### PR TITLE
Upgrade Agones to v1.49

### DIFF
--- a/infrastructure/agones-gke.tf
+++ b/infrastructure/agones-gke.tf
@@ -25,7 +25,7 @@ data "google_container_engine_versions" "regions" {
 module "agones_gke_standard_clusters" {
   for_each = var.game_gke_standard_clusters
 
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=v1.47.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=v1.49.0"
 
   cluster = {
     name             = each.key
@@ -49,7 +49,7 @@ module "agones_gke_standard_clusters" {
 module "agones_gke_autopilot_clusters" {
   for_each = var.game_gke_autopilot_clusters
 
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke-autopilot/?ref=v1.47.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke-autopilot/?ref=v1.49.0"
 
   cluster = {
     name     = each.key

--- a/platform/agones/skaffold.yaml
+++ b/platform/agones/skaffold.yaml
@@ -23,7 +23,7 @@ manifests:
         namespace: agones-system
         repo:  https://agones.dev/chart/stable
         remoteChart: agones
-        version: 1.47.0
+        version: 1.49.0
         setValues:
           agones.crds.cleanupOnDelete: false
           agones.allocator.disableMTLS: true


### PR DESCRIPTION
Updated Agones to use release v1.49

[Agones v1.49](https://github.com/googleforgames/agones/releases/tag/v1.49.0)