### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ deploys the game server Fleet to the global set of Agones Clusters sequentially 
 The Cloud Build process will build and archive a `Client-${BUILD_ID}.zip` file in the Google Cloud Storage
 Bucket `gs://${PROJECT_ID}-release-artifacts`.
 
-Use the [Cloud Storage Browser](https://console.cloud.google.com/storage/browser/) or `gsutil` to download
+Use the [Cloud Storage Browser](https://console.cloud.google.com/storage/browser/) or `gcloud storage` to download
 the file and `unzip` it locally.
 
 Run `launcher` to run the Game Launcher, and see [Playing The Game](#playing-the-game) for details on how to play the

--- a/infrastructure/files/game-client-startup.sh
+++ b/infrastructure/files/game-client-startup.sh
@@ -93,7 +93,7 @@ sudo touch /opt/game-client/init.lock
 project=$(curl http://metadata.google.internal/computeMetadata/v1/project/project-id -H Metadata-Flavor:Google)
 storage_bucket="gs://$project-release-artifacts"
 
-sudo gsutil cp "$storage_bucket/update-client.sh" /opt/game-client/update-client.sh
+sudo gcloud storage cp "$storage_bucket/update-client.sh" /opt/game-client/update-client.sh
 sudo chmod o+x /opt/game-client/update-client.sh
 
 # Rebooting to disable GSP Firmware because Nvidia says so.

--- a/infrastructure/files/update-client.sh
+++ b/infrastructure/files/update-client.sh
@@ -22,10 +22,10 @@ set -euxo pipefail
 
 project=$(curl http://metadata.google.internal/computeMetadata/v1/project/project-id -H Metadata-Flavor:Google)
 storage_bucket="gs://$project-release-artifacts"
-latest_client=$(gsutil ls -l "$storage_bucket/*.zip" | sort -k 2 -r | head -n 2 | tail -n 1 | awk '{print $3}')
+latest_client=$(gcloud storage ls --long "$storage_bucket/*.zip" | sort -k 2 -r | head -n 2 | tail -n 1 | awk '{print $3}')
 
 mkdir -p ~/Desktop/Client || true
 
-gsutil cp "$latest_client" ~/Desktop/Client/Client.zip
+gcloud storage cp "$latest_client" ~/Desktop/Client/Client.zip
 cd ~/Desktop/Client/
 unzip Client.zip


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
